### PR TITLE
Broken Font Link

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 import { AppRegistry, Text, View } from 'react-native';
 
-import { Font } from 'exponent';
+import { Font } from 'expo';
 import React from 'react';
 
 class App extends React.Component {
@@ -16,7 +16,7 @@ class App extends React.Component {
   async componentDidMount() {
     await Font.loadAsync({
       awesome:
-        'https://github.com/FortAwesome/Font-Awesome/raw/master/fonts/fontawesome-webfont.ttf',
+        'https://github.com/FortAwesome/Font-Awesome/raw/master/web-fonts-with-css/webfonts/fa-regular-400.ttf',
     });
     this.setState({ fontLoaded: true });
   }


### PR DESCRIPTION
The old link does not work anymore.
Please refer to the latest documentation on: https://docs.expo.io/versions/latest/guides/using-custom-fonts